### PR TITLE
Add droopy slime font for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # collectible-catalogue-v1
 
-This repo contains a simple website displaying **Hello World!**.
+This project hosts a simple landing page showcasing a small catalogue of collectible cards. The cards on the page are static examples with a modern design and pricing information.
 
 ## Running locally
 
-Open `index.html` in your browser.
+Open `index.html` in your browser to view the site.
 
 ## Deploying on GitHub Pages
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,54 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hello World!</title>
+    <title>Goopies Collection</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Creepster&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>Hello World!</h1>
+    <header class="hero">
+        <div class="hero-content">
+            <h1>Goopies Collection</h1>
+            <p>Your destination for epic collectible cards</p>
+        </div>
+    </header>
+
+    <main class="catalogue">
+        <h2>Featured Cards</h2>
+        <div class="cards">
+            <div class="card">
+                <img src="https://images.unsplash.com/photo-1531297484001-80022131f5a1?auto=format&fit=crop&w=400&q=60" alt="Dragon Warrior">
+                <h3>Dragon Warrior</h3>
+                <p>An ancient warrior with fire in his veins.</p>
+                <span class="price">$4.99</span>
+                <button class="buy">Buy Now</button>
+            </div>
+            <div class="card">
+                <img src="https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=400&q=60" alt="Mystic Elf">
+                <h3>Mystic Elf</h3>
+                <p>A powerful sorceress from the enchanted forest.</p>
+                <span class="price">$3.49</span>
+                <button class="buy">Buy Now</button>
+            </div>
+            <div class="card">
+                <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=400&q=60" alt="Shadow Ninja">
+                <h3>Shadow Ninja</h3>
+                <p>Master of stealth and silent attacks.</p>
+                <span class="price">$5.99</span>
+                <button class="buy">Buy Now</button>
+            </div>
+            <div class="card">
+                <img src="https://images.unsplash.com/photo-1517816743773-6e0fd518b4a6?auto=format&fit=crop&w=400&q=60" alt="Space Captain">
+                <h3>Space Captain</h3>
+                <p>Exploring galaxies in search of new adventures.</p>
+                <span class="price">$6.49</span>
+                <button class="buy">Buy Now</button>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <p>&copy; 2023 Goopies Collection. All rights reserved.</p>
+    </footer>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,105 @@
+body {
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    background-color: #f2f2f2;
+    color: #333;
+}
+
+h1, h2, h3 {
+    font-family: 'Creepster', cursive;
+    color: #fff;
+    text-shadow: -2px 0 #4e54c8, 2px 0 #4e54c8, 0 2px #4e54c8, 0 -2px #4e54c8;
+}
+
+.hero {
+    background: linear-gradient(120deg, #4e54c8, #8f94fb);
+    color: white;
+    text-align: center;
+    padding: 80px 20px;
+}
+
+.hero-content h1 {
+    font-size: 3em;
+    margin: 0;
+}
+
+.hero-content p {
+    font-size: 1.2em;
+    margin-top: 10px;
+    font-weight: 300;
+}
+
+.catalogue {
+    max-width: 1200px;
+    margin: 40px auto;
+    padding: 0 20px;
+}
+
+.catalogue h2 {
+    text-align: center;
+    margin-bottom: 30px;
+    font-weight: 400;
+}
+
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    overflow: hidden;
+    text-align: center;
+    padding-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.card img {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
+}
+
+.card h3 {
+    margin: 15px 0 10px;
+    font-size: 1.3em;
+}
+
+.card p {
+    padding: 0 15px;
+    flex-grow: 1;
+}
+
+.price {
+    font-size: 1.1em;
+    font-weight: 700;
+    margin-top: 10px;
+}
+
+.buy {
+    background-color: #4e54c8;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    margin-top: 15px;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+}
+
+.buy:hover {
+    background-color: #3d40a2;
+}
+
+.footer {
+    background: #222;
+    color: white;
+    text-align: center;
+    padding: 20px 0;
+    font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- import **Creepster** font for a dripping style
- apply droopy white text styling to all header elements

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686a18fb7ce483228af69b0148961404